### PR TITLE
Foxy cudnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,68 @@
-# darknet_ros_yolov4
-darknet_ros + ROS2 Foxy + OpenCV4 + CUDA 11.2
+# darknet_ros_yolov4 (with cuDNN)
+darknet_ros + ROS2 Foxy + OpenCV4 + CUDA 11.2 + ___CUDNN (FP16)___ :fire::fire: :fire:
 
 
 
-I've been wanting to make the ROS2 + YOLO v4 implementation happen for a long time, and I'm happy to report that I was able to implement it.
+I've been wanting to make the ROS2 + YOLO v4 + __cuDNN__ implementation happen for a long time, and I'm happy to report that I was able to implement it.
 
 ## Main changes
 - __Support for YOLO v4__ : Switched the submodule to the master branch of [AlexeyAB/darknet.](https://github.com/AlexeyAB/darknet)
 - __Removed IPL__ : Switched from IPL to CV::Mat for OpenCV4 support.
+- __Support CUDNN__
 
 ## Requirements
 - ROS2 Foxy
-- OpenCV4 ($ sudo apt install ros-foxy-vision-opencv)
+- OpenCV 4.2
 - CUDA 10 or 11 (tested with CUDA 11.2)
+- cuDNN 8.1 ([Installation tutorial](https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html))
 
 ## Installation
-```
+```bash
 $ source /opt/ros/foxy/setup.bash
 $ mkdir -p ~/ros2_ws/src
 $ cd ~/ros2_ws/src
-$ git clone --recursive https://github.com/Ar-Ray-code/darknet_ros_yolov4.git
+$ git clone --recursive --branch foxy-cudnn  https://github.com/Ar-Ray-code/darknet_ros_yolov4.git
 $ darknet_ros_yolov4/darknet_ros/rm_darknet_CMakeLists.sh
 $ cd ~/ros2_ws
 $ colcon build --symlink-install
 ```
+## Edit CMakeLists.txt
+
+Darknet can be made even faster by enabling CUDNN_HALF(FP16), but you need to specify the appropriate architecture.
+
+Open the CMakeLists.txt file and change the following.
+
+At line 40...
+
+```cmake
+...
+find_package(CUDNN)
+
+if(CUDNN_FOUND)
+    set(ADDITIONAL_CXX_FLAGS "${ADDITIONAL_CXX_FLAGS} -DCUDNN")
+endif()
+
+set(CMAKE_CUDA_ARCHITECTURES 75) # <- Example (TU102) : 75
+
+if ( 70 IN_LIST CMAKE_CUDA_ARCHITECTURES OR
+     72 IN_LIST CMAKE_CUDA_ARCHITECTURES OR
+...
+```
+
+In the future, we are considering automatic detection of GPU architecture.
+
 ## Demo
 
 Connect your webcam to your PC.
 
 ### Terminal 1
-```
+```bash
 $ source /opt/ros/foxy/setup.bash
 $ source ~/ros2_ws/install/local_setup.bash
 $ ros2 run v4l2_camera v4l2_camera_node --ros-args -r __ns:=/camera/rgb
 ```
 ### Terminal 2
-```
+```bash
 $ source /opt/ros/foxy/setup.bash
 $ source ~/ros2_ws/install/local_setup.bash
 $ ros2 run darknet_ros yolov4.launch.py
@@ -55,13 +82,25 @@ Using YOLO v4 consumes a lot of GPU memory and lowers the frame rate, so you nee
 | GPU    | NVIDIA GeForce RTX 2080 Ti (GDDR6 11GB) |
 | Driver | 460.32.03                               |
 
-### Performance
+### Performance (Not using cuDNN FP16)
 
 YOLO v3 : 67 fps , uses 1781MB of VRAM
 
 YOLO v4 : 29 fps , uses 3963MB of VRAM
 
 Scaled YOLO v4 : 51 fps , uses 2831MB of VRAM
+
+### Performance (Using cuDNN FP16)
+
+YOLO v4 : 40 fps (+10fps)
+
+Scaled YOLO v4 : 60fps (+9fps)
+
+YOLO v4-tiny : 140fps+ (MAX 150fps:fire:)
+
+YOLO v2-tiny : 135fps+
+
+
 
 ![E2tRQvnUcAQqn8O](https://user-images.githubusercontent.com/67567093/121984014-35d3e100-cdcd-11eb-9959-b1063a9a0b2b.jpeg)
 

--- a/README.md
+++ b/README.md
@@ -41,26 +41,8 @@ Darknet can be made even faster by enabling CUDNN_HALF(FP16), but you need to sp
 FP16 is automatically enabled for GPUs of the Turing or Ampere architecture if the appropriate cuDNN is installed. To disable it, change line 12 to `set(FP16_ENABLE OFF)`.
 
 The Jetson AGX Xavier and TITAN V support FP16, but due to their Volta architecture, auto-detection is not possible. (Sorry... :( )
-In that case, please comment out line 17 ` set(CMAKE_CUDA_ARCHITECTURES 72)
 
-Open the CMakeLists.txt file and change the following.
-
-At line 10...
-
-```cmake
-...
-set(CUDA_ENABLE ON)
-set(CUDNN_ENABLE ON)
-set(FP16_ENABLE ON)
-
-# Jetson AGX Xavier & TITAN V is under version of Turing. So, please set manually.
-# Turing or Ampere GPUs, FP16 is automatically enabled.
-
-# set(CMAKE_CUDA_ARCHITECTURES 72)
-...
-```
-
-In the future, I'm considering automatic detection of GPU architecture.
+In that case, please comment out line 17 `set(CMAKE_CUDA_ARCHITECTURES 72)`
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # darknet_ros_yolov4 (with cuDNN)
-darknet_ros + ROS2 Foxy + OpenCV4 + CUDA 11.2 + ___CUDNN (FP16)___ :fire::fire: :fire:
+darknet_ros + ROS2 Foxy + OpenCV4 + CUDA 11.2 + ___CUDNN (FP16)___ :fire::fire::fire:
 
 
 
@@ -49,7 +49,7 @@ if ( 70 IN_LIST CMAKE_CUDA_ARCHITECTURES OR
 ...
 ```
 
-In the future, we are considering automatic detection of GPU architecture.
+In the future, I'm considering automatic detection of GPU architecture.
 
 ## Demo
 
@@ -90,7 +90,7 @@ YOLO v4 : 29 fps , uses 3963MB of VRAM
 
 Scaled YOLO v4 : 51 fps , uses 2831MB of VRAM
 
-### Performance (Using cuDNN FP16)
+### Performance (using cuDNN FP16)
 
 YOLO v4 : 40 fps (+10fps)
 


### PR DESCRIPTION
cuDNN (FP16) makes Darknet very fast. :fire::fire::fire:
For example, applying cuDNN (FP16) to YOLO v4 can greatly speed up 29fps to 40fps (+11fps) :exclamation::exclamation: 

Let's all use cuDNN. cuDNN is the best!!!

This option is only enabled on Turing and later GPUs and Volta architecture GPUs (Jetson AGX Xavier and TITAN V). :sunglasses:

## Build

The same as before.

cuDNN and FP16 are automatically detected.
If you are using Jetson AGX Xavier or TITAN V, or if you are running benchmark tests, you can enable FP16 mode by rewriting CMakeLists.txt.

## YOLO v4-tiny (FP16)

<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">darknet-ros-yolov4において、CUDNN+CUDNN_HALFの導入に成功しました🎉🎉🎉<br>yolov4-tiny（416）において最大150.0fps（RTX 2080Ti）🔥🔥🔥🔥🔥🔥🔥🔥<a href="https://twitter.com/hashtag/ROS?src=hash&amp;ref_src=twsrc%5Etfw">#ROS</a> <a href="https://t.co/K2ft34s9sM">pic.twitter.com/K2ft34s9sM</a></p>&mdash; Ar-Ray (@Ray255Ar) <a href="https://twitter.com/Ray255Ar/status/1406442563012161540?ref_src=twsrc%5Etfw">June 20, 2021</a></blockquote>

![E4SvGNDVUAMRMOG](https://user-images.githubusercontent.com/67567093/122789724-92199200-d2f2-11eb-9b45-c5fa8f1396c6.jpeg)

![E4Sv5vOVoAUqUhz](https://user-images.githubusercontent.com/67567093/122789768-9e055400-d2f2-11eb-8216-efa5fb0883bc.jpeg)
